### PR TITLE
Lint on strings in logical expressions

### DIFF
--- a/rules/no-en.js
+++ b/rules/no-en.js
@@ -79,6 +79,17 @@ module.exports = function(context) {
         if (node.init.quasis.some(el => isEnglish(el.value.raw))) {
           context.report({node: node.init, message})
         }
+      } else if (node.init.type === 'LogicalExpression') {
+        const nodes = [node.init.left, node.init.right]
+        nodes.forEach(childNode => {
+          if (childNode.type === 'Literal' && isEnglish(childNode.value)) {
+            context.report({node: childNode, message})
+          } else if (childNode.type === 'TemplateLiteral') {
+            if (childNode.quasis.some(el => isEnglish(el.value.raw))) {
+              context.report({node: childNode, message})
+            }
+          }
+        })
       }
     }
   }

--- a/tests/no-en.js
+++ b/tests/no-en.js
@@ -76,6 +76,18 @@ ruleTester.run('no-en', rule, {
       errors: [{message: error, type: 'TemplateLiteral'}]
     },
     {
+      code: 'var message = possibly_undefined_variable || `Some message text`',
+      errors: [{message: error, type: 'TemplateLiteral'}]
+    },
+    {
+      code: 'var message = possibly_undefined_variable || "Some message text"',
+      errors: [{message: error, type: 'Literal'}]
+    },
+    {
+      code: 'var message = "Some message text" || a_variable',
+      errors: [{message: error, type: 'Literal'}]
+    },
+    {
       code: 'message = `Some message text`',
       errors: [{message: error, type: 'TemplateLiteral'}]
     },


### PR DESCRIPTION
This should catch issues like `var message = possibly_undefined_variable || "untranslated string"`