### PR TITLE
Check right side of a logical expression for english

### DIFF
--- a/rules/no-en.js
+++ b/rules/no-en.js
@@ -36,6 +36,15 @@ function isAssert(node) {
 
 module.exports = function(context) {
   return {
+    LogicalExpression: function(node) {
+      if (node.right.type === 'Literal' && isEnglish(node.right.value)) {
+        context.report({node: node.right, message})
+      } else if (node.right.type === 'TemplateLiteral') {
+        if (node.right.quasis.some(el => isEnglish(el.value.raw))) {
+          context.report({node: node.right, message})
+        }
+      }
+    },
     AssignmentExpression: function(node) {
       if (node.right.type === 'Literal' && isEnglish(node.right.value)) {
         context.report({node: node.right, message})

--- a/tests/no-en.js
+++ b/tests/no-en.js
@@ -90,6 +90,14 @@ ruleTester.run('no-en', rule, {
     {
       code: 'list.push(`Some message text`)',
       errors: [{message: error, type: 'TemplateLiteral'}]
+    },
+    {
+      code: "someValue || 'Something went wrong'",
+      errors: [{message: error, type: 'Literal'}]
+    },
+    {
+      code: 'someValue || `Something went ${adjective} wrong`',
+      errors: [{message: error, type: 'TemplateLiteral'}]
     }
   ]
 })


### PR DESCRIPTION
Add a new violation when users use english on the right side of a logical expression.

I didn't check the left side since it doesn't seem people are using the LHS of a logical expression. If we have any examples of that, it's trivial to add the LHS case to this PR.

I ran this `github/github` and found 8 violations of this rule.

cc/ @github/web-systems