### PR TITLE
Add excludes option to exclude any function calls

### DIFF
--- a/rules/no-en.js
+++ b/rules/no-en.js
@@ -41,6 +41,20 @@ function matchesExcludesOption(node, context) {
 
   const excludes = context.options[0].excludes
   return excludes.some(exclude => {
+    if (exclude.includes('.')) {
+      const parts = exclude.split('.')
+      const lastPart = parts.shift()
+      let currentNode = node.callee
+      for (const part of parts.reverse()) {
+        if (!currentNode.property || part !== currentNode.property.name) {
+          return false
+        }
+        currentNode = currentNode.object
+      }
+
+      return currentNode.name === lastPart
+    }
+
     const direct =
       node.callee.type === 'Identifier' && node.callee.name === exclude
     const member =

--- a/tests/no-en.js
+++ b/tests/no-en.js
@@ -38,12 +38,20 @@ ruleTester.run('no-en', rule, {
     'assert(false, "Should be true")',
     'assert(false, `Should be true`)',
     {
-      code: 'Sentry.captureMessage("Error message")',
+      code: 'Sentry.captureMessage("Error message 1")',
       options: [{excludes: ['Sentry']}]
     },
     {
-      code: 'Sentry.captureMessage("Error message")',
+      code: 'Sentry.captureMessage("Error message 2")',
       options: [{excludes: ['captureMessage']}]
+    },
+    {
+      code: 'A.Really.Deep.Function.Call("Error message")',
+      options: [{excludes: ['A.Really.Deep.Function.Call']}]
+    },
+    {
+      code: 'Sentry.captureMessage("Error message 3")',
+      options: [{excludes: ['Sentry.captureMessage']}]
     }
   ],
   invalid: [
@@ -108,8 +116,13 @@ ruleTester.run('no-en', rule, {
       errors: [{message: error, type: 'TemplateLiteral'}]
     },
     {
-      code: 'Sentry.captureMessage("Error message")',
+      code: 'Sentry.captureMessage("Error message 1")',
       options: [{excludes: ['Not this function']}],
+      errors: [{message: error, type: 'Literal'}]
+    },
+    {
+      code: 'Sentry.captureMessage("Error message 2")',
+      options: [{excludes: ['Sentry.otherFunction']}],
       errors: [{message: error, type: 'Literal'}]
     }
   ]

--- a/tests/no-en.js
+++ b/tests/no-en.js
@@ -124,6 +124,16 @@ ruleTester.run('no-en', rule, {
       code: 'Sentry.captureMessage("Error message 2")',
       options: [{excludes: ['Sentry.otherFunction']}],
       errors: [{message: error, type: 'Literal'}]
+    },
+    {
+      code: 'Sentry.captureMessage("Error message 3")',
+      options: [{excludes: ['Sentry.captureMessage.Not.A.Function']}],
+      errors: [{message: error, type: 'Literal'}]
+    },
+    {
+      code: 'Sentry.captureMessage("Error message 4")',
+      options: [{excludes: ['A.Really.Deep.Function.Call']}],
+      errors: [{message: error, type: 'Literal'}]
     }
   ]
 })

--- a/tests/no-en.js
+++ b/tests/no-en.js
@@ -36,7 +36,15 @@ ruleTester.run('no-en', rule, {
     'test("Test something", function(){})',
     'assert.equal(1, 2, "Should be false")',
     'assert(false, "Should be true")',
-    'assert(false, `Should be true`)'
+    'assert(false, `Should be true`)',
+    {
+      code: 'Sentry.captureMessage("Error message")',
+      options: [{excludes: ['Sentry']}]
+    },
+    {
+      code: 'Sentry.captureMessage("Error message")',
+      options: [{excludes: ['captureMessage']}]
+    }
   ],
   invalid: [
     {
@@ -98,6 +106,11 @@ ruleTester.run('no-en', rule, {
     {
       code: 'someValue || `Something went ${adjective} wrong`',
       errors: [{message: error, type: 'TemplateLiteral'}]
+    },
+    {
+      code: 'Sentry.captureMessage("Error message")',
+      options: [{excludes: ['Not this function']}],
+      errors: [{message: error, type: 'Literal'}]
     }
   ]
 })


### PR DESCRIPTION
This option would allow users to white list any function calls which are allowed to use english strings (such as error handling).

- I added tests cases for matching and not matching the rules.
- I added the ability to have nested exclude keys, and only match a full match